### PR TITLE
remove dependency on six

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -21,7 +21,6 @@ requirements:
   run:
     - python >=3.6
     - python-dateutil
-    - six
     - convertdate >=2.3.0
     - korean_lunar_calendar
     - hijri-converter


### PR DESCRIPTION
Fixes missed removal of `six` dependency in 0.11.3

@conda-forge-admin please rerender